### PR TITLE
dashboard layout with placeholders

### DIFF
--- a/frontend/src/app/App.css
+++ b/frontend/src/app/App.css
@@ -1,42 +1,6 @@
-#root {
+.app {
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;
   text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,10 +1,12 @@
 import './App.css'
 import DoorbellModal from "../features/doorbell/components/DoorbellModal.tsx";
+import DashboardPage from "../pages/dashboard/DashboardPage.tsx";
 
 export default function App() {
   return (
       <>
-        <DoorbellModal />
+          <DoorbellModal />
+          <DashboardPage />
       </>
   )
 }

--- a/frontend/src/app/index.css
+++ b/frontend/src/app/index.css
@@ -1,3 +1,4 @@
+/* index.css */
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -13,27 +14,39 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+/* Vollfläche */
+html, body, #root {
+  width: 100%;
+  height: 100%;
 }
 
 body {
   margin: 0;
   display: flex;
-  place-items: center;
+  flex-direction: column;
+  align-items: stretch;     /* nicht zentrieren */
   min-width: 320px;
-  min-height: 100vh;
+  min-height: 100%;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+/* Root-Container: keine Begrenzung, kein Padding */
+#root {
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  text-align: initial;
 }
+
+a {
+  font-weight: 500;
+  color: #646cff;
+  text-decoration: inherit;
+}
+a:hover { color: #535bf2; }
+
+h1 { font-size: 3.2em; line-height: 1.1; }
 
 button {
   border-radius: 8px;
@@ -46,23 +59,12 @@ button {
   cursor: pointer;
   transition: border-color 0.25s;
 }
-button:hover {
-  border-color: #646cff;
-}
+button:hover { border-color: #646cff; }
 button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
+button:focus-visible { outline: 4px auto -webkit-focus-ring-color; }
 
 @media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  :root { color: #213547; background-color: #ffffff; }
+  a:hover { color: #747bff; }
+  button { background-color: #f9f9f9; }
 }

--- a/frontend/src/features/dashboard/index.ts
+++ b/frontend/src/features/dashboard/index.ts
@@ -1,0 +1,1 @@
+export { DashboardLayout } from "./ui/DashboardLayout";

--- a/frontend/src/features/dashboard/ui/DashboardLayout.css
+++ b/frontend/src/features/dashboard/ui/DashboardLayout.css
@@ -1,0 +1,55 @@
+.dash-cols {
+    width: 100%;
+    height: 100vh;
+    padding: 24px;
+    box-sizing: border-box;
+
+    display: flex;
+    gap: 16px;
+}
+
+.col {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    min-height: 0;
+}
+
+.col-left  { flex: 2 1 0; }
+.col-right { flex: 1 1 0; }
+
+.block {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    flex: 1 1 0;
+}
+
+.block > .card {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: auto;
+}
+
+/* „auto“: nimmt nur Inhaltshöhe, verteilt restlichen Platz auf andere Blöcke */
+.block.auto   { flex: 0 0 auto; }
+
+/* Gewichte: mehr Wachstum im Verhältnis zu anderen „flex:1“-Blöcken */
+.block.grow-2 { flex: 2 1 0; }
+.block.grow-3 { flex: 3 1 0; }
+.block.grow-4 { flex: 4 1 0; }
+
+/* Weniger Gewicht als Standard */
+.block.shrink { flex: 0.5 1 0; }
+
+@media (max-width: 640px) {
+    .dash-cols {
+        flex-direction: column;
+        height: auto;
+    }
+    .block {
+        flex: 0 0 auto;
+    }
+}

--- a/frontend/src/features/dashboard/ui/DashboardLayout.tsx
+++ b/frontend/src/features/dashboard/ui/DashboardLayout.tsx
@@ -1,0 +1,54 @@
+import "./DashboardLayout.css";
+
+type SlotClass =
+    | "" | "auto"
+    | "grow-2" | "grow-3"
+    | "grow-4" | "shrink";
+
+type Props = {
+    topLeft?: React.ReactNode;
+    topRight?: React.ReactNode;
+    mainLeft?: React.ReactNode;
+    mainRight?: React.ReactNode;
+    bottomLeft?: React.ReactNode;
+    bottomRight?: React.ReactNode;
+
+    /** optionale Klassen zur Höhenverteilung je Slot */
+    topLeftClass?: SlotClass;
+    topRightClass?: SlotClass;
+    mainLeftClass?: SlotClass;
+    mainRightClass?: SlotClass;
+    bottomLeftClass?: SlotClass;
+    bottomRightClass?: SlotClass;
+
+    className?: string;
+};
+
+export function DashboardLayout({
+                                    topLeft, topRight,
+                                    mainLeft, mainRight,
+                                    bottomLeft, bottomRight,
+                                    topLeftClass = "",
+                                    topRightClass = "",
+                                    mainLeftClass = "",
+                                    mainRightClass = "",
+                                    bottomLeftClass = "",
+                                    bottomRightClass = "",
+                                    className
+                                }: Readonly<Props>) {
+    return (
+        <main className={["dash-cols", className].filter(Boolean).join(" ")}>
+            <section className="col col-left">
+                {topLeft     && <div className={["block", topLeftClass    ].filter(Boolean).join(" ")}>{topLeft}</div>}
+                {mainLeft    && <div className={["block", mainLeftClass   ].filter(Boolean).join(" ")}>{mainLeft}</div>}
+                {bottomLeft  && <div className={["block", bottomLeftClass ].filter(Boolean).join(" ")}>{bottomLeft}</div>}
+            </section>
+
+            <aside className="col col-right">
+                {topRight    && <div className={["block", topRightClass   ].filter(Boolean).join(" ")}>{topRight}</div>}
+                {mainRight   && <div className={["block", mainRightClass  ].filter(Boolean).join(" ")}>{mainRight}</div>}
+                {bottomRight && <div className={["block", bottomRightClass].filter(Boolean).join(" ")}>{bottomRight}</div>}
+            </aside>
+        </main>
+    );
+}

--- a/frontend/src/features/doorbell/components/DoorbellModal.tsx
+++ b/frontend/src/features/doorbell/components/DoorbellModal.tsx
@@ -26,7 +26,7 @@ export default function DoorbellModal() {
     // State
     const [wsOpen, setWsOpen] = useState(false);
     const [modalOpen, setModalOpen] = useState(false);
-    const [audible, setAudible] = useState(false);         // <-- neu: ersetzt soundEnabled + remoteMuted
+    const [audible, setAudible] = useState(false);
     const [remoteVolume, setRemoteVolume] = useState(1);
     const [sigState, setSigState] = useState<RTCSignalingState>("stable");
     const [iceConn, setIceConn] = useState<RTCIceConnectionState>("new");

--- a/frontend/src/pages/dashboard/DashboardPage.css
+++ b/frontend/src/pages/dashboard/DashboardPage.css
@@ -1,0 +1,86 @@
+:root{
+    --radius: 12px;
+    --border: rgba(255,255,255,0.14);
+}
+
+.card{
+    background-color: #1a1a1a;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 16px;
+
+    /* erlaubt inneres Scrolling in hohen Slots */
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+@media (prefers-color-scheme: light) {
+    .card{
+        background-color: #f9f9f9;
+        border: 1px solid rgba(0,0,0,0.12);
+    }
+}
+
+.row-split{
+    display: flex;
+    gap: 16px;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.stack{ display:flex; flex-direction:column; gap:4px; }
+.stack.right{ align-items:flex-end; text-align:right; }
+
+.title{ font-weight:600; margin-bottom:8px; }
+.eyebrow{ font-size:12px; letter-spacing:.04em; text-transform:uppercase; opacity:.7; }
+.big{ font-size:28px; line-height:1; }
+.muted{ opacity:.65; }
+
+.list{
+    display:grid;
+    gap:10px;
+    padding-left:0;
+    margin:0;
+    list-style:none;
+
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: auto;
+}
+.list.compact{ gap:6px; }
+
+.item-text{ margin-left:8px; }
+
+.badge{
+    font-size:12px;
+    padding:2px 8px;
+    border-radius:999px;
+    border:1px solid rgba(255,255,255,0.12);
+    background: rgba(255,255,255,0.06);
+}
+.badge.ok{ box-shadow: 0 0 0 1px rgba(0,255,128,0.25) inset; }
+.badge.warn{ box-shadow: 0 0 0 1px rgba(255,200,0,0.25) inset; }
+
+.chip{
+    display:inline-flex; align-items:center; gap:6px;
+    padding:4px 10px; border-radius:999px;
+    background: rgba(255,255,255,0.06);
+    border:1px solid rgba(255,255,255,0.12);
+    margin:6px 0;
+}
+.chip-ok{ box-shadow: 0 0 0 1px rgba(0,255,128,0.25) inset; }
+
+.btn{ width:100%; margin-top:8px; }
+
+.dot{
+    display:inline-block; width:8px; height:8px; border-radius:50%;
+    background: currentColor; margin-right:8px; vertical-align:middle;
+}
+
+.swatch{
+    display:inline-block; width:10px; height:10px; border-radius:2px;
+    margin-right:8px; vertical-align:middle;
+}
+.swatch.paper{ background:#4da3ff; }
+.swatch.residual{ background:#9e9e9e; }

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -1,0 +1,87 @@
+import { DashboardLayout } from "../../features/dashboard";
+import "./DashboardPage.css";
+
+export default function DashboardPage() {
+    return (
+        <DashboardLayout
+            topLeftClass="auto"
+            mainLeftClass="grow-2"
+            bottomLeftClass="grow-2"
+
+            topRightClass="grow-2"
+            mainRightClass="grow-2"
+            bottomRightClass="auto"
+
+            topLeft={
+                <div className="card row-split">
+                    <div className="stack">
+                        <div className="eyebrow">Jetzt</div>
+                        <div className="big">11:23</div>
+                        <div className="muted">Mo, 9. Sept</div>
+                    </div>
+                    <div className="stack right">
+                        <div className="eyebrow">Wetter</div>
+                        <div className="big">19°C · Sonne</div>
+                        <div className="muted">Morgen: Regen</div>
+                    </div>
+                </div>
+            }
+
+            topRight={
+                <div className="card">
+                    <div className="eyebrow">a-door</div>
+                    <div className="chip chip-ok">● Online</div>
+                    <div className="muted">zuletzt gesehen: vor 2 min</div>
+                </div>
+            }
+
+            mainLeft={
+                <div className="card">
+                    <div className="title">Klingel-Historie</div>
+                    <ul className="list">
+                        <li>
+                            <span className="badge ok">angenommen</span>
+                            <span className="item-text">09:42 · Besucher</span>
+                        </li>
+                        <li>
+                            <span className="badge warn">verpasst</span>
+                            <span className="item-text">07:15 · Lieferung</span>
+                        </li>
+                        <li>
+                            <span className="badge ok">angenommen</span>
+                            <span className="item-text">Gestern · 18:03</span>
+                        </li>
+                    </ul>
+                </div>
+            }
+
+            mainRight={
+                <div className="card stack">
+                    <div className="title">Aktionen</div>
+                    <button className="btn">⚙️ Einstellungen</button>
+                    <button className="btn secondary">➕ Weitere Apps</button>
+                </div>
+            }
+
+            bottomLeft={
+                <div className="card">
+                    <div className="title">Termine · heute & morgen</div>
+                    <ul className="list">
+                        <li><span className="dot" /> Heute · 14:00 – Arzt</li>
+                        <li><span className="dot" /> Morgen · 07:00 – Müll</li>
+                    </ul>
+                </div>
+            }
+
+            bottomRight={
+                <div className="card">
+                    <div className="title">Müllkalender</div>
+                    <ul className="list compact">
+                        <li><span className="swatch paper" /> Morgen: Papier</li>
+                        <li><span className="swatch residual" /> Fr: Restmüll</li>
+                    </ul>
+                </div>
+            }
+        />
+    );
+}

--- a/frontend/src/shared/components/ui/Modal.css
+++ b/frontend/src/shared/components/ui/Modal.css
@@ -1,38 +1,41 @@
-.modal-root {
+.modal {
     position: fixed;
     inset: 0;
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+
     display: grid;
     place-items: center;
-    z-index: 9999;
+
+    width: 100vw;
+    height: 100vh;
+    box-sizing: border-box;
 }
 
-.modal-overlay {
-    position: absolute;
-    inset: 0;
+.modal::backdrop {
     background: rgba(0,0,0,0.6);
 }
 
 .modal-panel {
     position: relative;
     width: min(92vw, 900px);
-    background: #121212;
-    color: #eee;
-    border-radius: 12px;
-    padding: 12px;
-    border: none;
-    box-shadow: 0 10px 30px rgba(0,0,0,0.4);
     max-height: 90vh;
     overflow: auto;
-}
-
-.modal-content::backdrop {
-    background: rgba(0,0,0,0.6);
+    background: #121212;
+    color: #eee;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 12px;
+    padding: 12px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.4);
 }
 
 .modal-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 12px;
     margin-bottom: 8px;
 }
 .modal-header h3 {

--- a/frontend/src/shared/components/ui/Modal.css
+++ b/frontend/src/shared/components/ui/Modal.css
@@ -12,7 +12,8 @@
     background: rgba(0,0,0,0.6);
 }
 
-.modal-content {
+.modal-panel {
+    position: relative;
     width: min(92vw, 900px);
     background: #121212;
     color: #eee;
@@ -34,4 +35,6 @@
     align-items: center;
     margin-bottom: 8px;
 }
-.modal-header h3 { margin: 0; }
+.modal-header h3 {
+    margin: 0;
+}


### PR DESCRIPTION
This PR introduces the initial dashboard layout for the hub UI.
It sets up the overall structure and adds placeholder content for the main sections.

Changes:
- Added DashboardLayout feature component (2/3–1/3 column split)
- Created DashboardPage with placeholder blocks for: (Time & Weather, a-door Status, Doorbell History, Actions (Settings, Apps), Appointments, Waste Calendar)
- Base CSS for full-screen layout with padding and flexible block heights
- Cards support scrolling if content exceeds available space


Notes:
- All current blocks are placeholders (no live data yet).
- Provides a foundation to plug in real widgets/features in follow-up PRs.